### PR TITLE
Standardise fail-fast validation across JSON load paths

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -880,7 +880,7 @@ exit
 
 <box type="warning" seamless>
 
-Please follow this format carefully. Files that do not adhere to the required format will be considered invalid.
+Please follow this format carefully. Files that do not adhere to the required format will not be loaded.
 
 </box>
 
@@ -930,14 +930,32 @@ Please follow this format carefully. Files that do not adhere to the required fo
 
 </panel>
 
+<box type="tip" seamless>
+
+You should always back up the files before editing.
+
+</box>
+
 </panel>
 
-<panel header="I edited the data file directly and now VendorVault is not working. What should I do?" type="seamless">
+<panel header="I edited the data files and VendorVault does not load my data. What can I do?" type="seamless">
 
-You can try the following steps:
+If VendorVault cannot load your data, it means the edited file has invalid data.
 
-1. Restore from backup: If you made a backup of the data file before editing, you can restore the original data file by replacing the edited data files in the data folder with the backup.
-2. Start with a new data file: If you do not have a backup, you can delete the existing data file (or move it to a different location for safekeeping) and start VendorVault again. After entering a valid command, this will create a new, sample data file.
+| Your situation                                                                               | What to do                                                                        | What happens next                                               |
+|----------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|-----------------------------------------------------------------|
+| You backed up the file before editing                                                        | Replace the edited file in `data/` with your backup                               | Restart the app and your original data is loaded                |
+| You did not back up the file before editing, and you have not run any command after startup	 | Back up the edited file                                                           | Fix the edited file                                             |
+| You did not back up the file before editing, and you already ran command(s) after startup    | The edited files have been wiped. Delete the empty files and restart VendorVault. | VendorVault will recreate sample data after you run any command |
+
+<box type="info" seamless>
+
+To fix your edited file,
+1. Check your terminal for `WARNING...` messages.
+2. Correct the fields as shown.
+3. Restart the app. Repeat steps 1-2 until no more `WARNING...` messages are shown.
+
+</box>
 
 </panel>
 

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -1,8 +1,6 @@
 package seedu.address;
 
-import static seedu.address.model.util.VendorVaultConsistencyUtil.findUnknownVendorLinksFromJson;
 import static seedu.address.model.util.VendorVaultConsistencyUtil.validateOrThrow;
-import static seedu.address.ui.Messages.DUPLICATE_IDENTIFIER_PREFIX;
 import static seedu.address.ui.Messages.MESSAGE_COULD_NOT_LOAD_STARTING_EMPTY_ADDRESS_BOOK;
 import static seedu.address.ui.Messages.MESSAGE_COULD_NOT_LOAD_STARTING_EMPTY_ALIAS;
 import static seedu.address.ui.Messages.MESSAGE_COULD_NOT_LOAD_STARTING_EMPTY_INVENTORY;
@@ -13,12 +11,10 @@ import static seedu.address.ui.Messages.MESSAGE_LOG_SEPARATOR;
 import static seedu.address.ui.Messages.MESSAGE_POPULATED_EMPTY_ALIAS_FILE;
 import static seedu.address.ui.Messages.MESSAGE_POPULATED_SAMPLE_ADDRESS_BOOK;
 import static seedu.address.ui.Messages.MESSAGE_POPULATED_SAMPLE_INVENTORY;
-import static seedu.address.ui.Messages.MESSAGE_UNKNOWN_VENDOR_EMAIL;
 import static seedu.address.ui.Messages.NEWLINE;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Optional;
 import java.util.logging.Logger;
 
@@ -175,7 +171,6 @@ public class MainApp extends Application {
         }
 
         String details = illegalValueDetails.get();
-        logUnknownVendorIssuesIfDuplicateIdentifier(inventoryFilePath, initialData, details);
     }
 
     private ReadOnlyAliases loadInitialAliases(Storage storage) {
@@ -220,19 +215,6 @@ public class MainApp extends Application {
 
         String details = cause.getMessage();
         return details == null ? Optional.empty() : Optional.of(details);
-    }
-
-    private void logUnknownVendorIssuesIfDuplicateIdentifier(Path inventoryFilePath, ReadOnlyAddressBook initialData,
-                                                             String details) {
-        if (!details.startsWith(DUPLICATE_IDENTIFIER_PREFIX)) {
-            return;
-        }
-
-        List<String> issues = findUnknownVendorLinksFromJson(initialData, inventoryFilePath);
-        for (String issue : issues) {
-            logger.warning(MESSAGE_ILLEGAL_VALUES_FOUND_IN + inventoryFilePath + MESSAGE_LOG_SEPARATOR
-                    + MESSAGE_UNKNOWN_VENDOR_EMAIL + issue + ".");
-        }
     }
 
     private void logIllegalValueIssue(Path filePath, String details) {

--- a/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
+++ b/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
@@ -7,7 +7,6 @@ import static seedu.address.storage.JsonSerializableAddressBook.MESSAGE_DUPLICAT
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -26,6 +25,7 @@ public class JsonAddressBookStorage implements AddressBookStorage {
     private static final String MESSAGE_DUPLICATE_CONTACT_EMAIL = "Duplicate contact email '";
     private static final String MESSAGE_QUOTE_SUFFIX = "'";
     private static final String MESSAGE_QUOTE_AT = "' at ";
+    private static final String PERIOD = ".";
 
     private final Path filePath;
 
@@ -61,8 +61,9 @@ public class JsonAddressBookStorage implements AddressBookStorage {
             return Optional.of(jsonAddressBook.get().toModelType());
         } catch (IllegalValueException ive) {
             if (MESSAGE_DUPLICATE_PERSON.equals(ive.getMessage())) {
-                List<String> duplicateEmails = jsonAddressBook.get().findDuplicateEmails();
-                String detailedMessage = buildDuplicateEmailErrorMessage(filePath, duplicateEmails);
+                String detailedMessage = jsonAddressBook.get().findFirstDuplicateEmail()
+                        .map(email -> buildDuplicateEmailErrorMessage(filePath, email))
+                        .orElse(MESSAGE_DUPLICATE_PERSON);
 
                 throw new DataLoadingException(new IllegalValueException(detailedMessage, ive));
             }
@@ -71,24 +72,15 @@ public class JsonAddressBookStorage implements AddressBookStorage {
         }
     }
 
-    private String buildDuplicateEmailErrorMessage(Path filePath, List<String> duplicateEmails) {
-        if (duplicateEmails.isEmpty()) {
-            return MESSAGE_DUPLICATE_PERSON;
+    private String buildDuplicateEmailErrorMessage(Path filePath, String duplicateEmail) {
+        List<Integer> lineNumbers = findFieldLineNumbers(filePath, EMAIL_FIELD, duplicateEmail);
+
+        if (lineNumbers.isEmpty()) {
+            return MESSAGE_DUPLICATE_CONTACT_EMAIL + duplicateEmail + MESSAGE_QUOTE_SUFFIX + PERIOD;
         }
 
-        List<String> details = new ArrayList<>();
-        for (String email : duplicateEmails) {
-            List<Integer> lineNumbers = findFieldLineNumbers(filePath, EMAIL_FIELD, email);
-
-            if (lineNumbers.isEmpty()) {
-                details.add(MESSAGE_DUPLICATE_CONTACT_EMAIL + email + MESSAGE_QUOTE_SUFFIX);
-            } else {
-                details.add(MESSAGE_DUPLICATE_CONTACT_EMAIL + email + MESSAGE_QUOTE_AT
-                        + formatLineReference(lineNumbers));
-            }
-        }
-
-        return String.join("; ", details) + ".";
+        return MESSAGE_DUPLICATE_CONTACT_EMAIL + duplicateEmail + MESSAGE_QUOTE_AT
+                + formatLineReference(lineNumbers) + PERIOD;
     }
 
     @Override

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -1,9 +1,12 @@
 package seedu.address.storage;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -74,6 +77,23 @@ class JsonSerializableAddressBook {
                 .filter(entry -> entry.getValue() > 1)
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toList());
+    }
+
+    Optional<String> findFirstDuplicateEmail() {
+        Set<String> seenEmails = new HashSet<>();
+
+        for (JsonAdaptedPerson person : persons) {
+            String email = person.getEmail();
+            if (email == null) {
+                continue;
+            }
+
+            if (!seenEmails.add(email)) {
+                return Optional.of(email);
+            }
+        }
+
+        return Optional.empty();
     }
 
 }

--- a/src/test/data/JsonAddressBookStorageTest/multipleDuplicateEmailAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/multipleDuplicateEmailAddressBook.json
@@ -1,0 +1,23 @@
+{
+  "persons": [ {
+    "name": "One",
+    "phone": "91234567",
+    "email": "alice@example.com",
+    "address": "Address One"
+  }, {
+    "name": "Two",
+    "phone": "91234568",
+    "email": "alice@example.com",
+    "address": "Address Two"
+  }, {
+    "name": "Three",
+    "phone": "91234569",
+    "email": "second@example.com",
+    "address": "Address Three"
+  }, {
+    "name": "Four",
+    "phone": "91234570",
+    "email": "second@example.com",
+    "address": "Address Four"
+  } ]
+}

--- a/src/test/java/seedu/address/MainAppTest.java
+++ b/src/test/java/seedu/address/MainAppTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalProducts.RICE;
-import static seedu.address.ui.Messages.DUPLICATE_IDENTIFIER_PREFIX;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
@@ -67,11 +66,9 @@ public class MainAppTest {
     private static final String METHOD_GET_ILLEGAL_VALUE_DETAILS = "getIllegalValueDetails";
     private static final String METHOD_INIT_MODEL_MANAGER = "initModelManager";
     private static final String METHOD_LOG_INVENTORY_LOADING_ISSUE = "logInventoryLoadingIssue";
-    private static final String METHOD_LOG_UNKNOWN_VENDOR_ISSUES = "logUnknownVendorIssuesIfDuplicateIdentifier";
     private static final String METHOD_LOG_ILLEGAL_VALUE_ISSUE = "logIllegalValueIssue";
     private static final String METHOD_INIT_LOGGING = "initLogging";
     private static final String NON_DUPLICATE_DETAILS = "Some non-duplicate error";
-    private static final String DUPLICATE_DETAILS = DUPLICATE_IDENTIFIER_PREFIX + " 'SKU-1001' at line 7.";
     private static final String DETAILS_WITH_NEWLINE = "line one\nline two";
     private static final Path UNKNOWN_VENDOR_MIXED_FILE = Path.of("src", "test", "data",
             "VendorVaultConsistencyUtilTest", "unknownVendorMixedInventory.json");
@@ -362,28 +359,6 @@ public class MainAppTest {
     }
 
     @Test
-    public void logUnknownVendorIssuesIfDuplicateIdentifier_nonDuplicatePrefix_returnsEarly() {
-        TestableMainApp app = new TestableMainApp();
-
-        assertDoesNotThrow(() -> invokeLogUnknownVendorIssuesIfDuplicateIdentifier(
-                app,
-                UNKNOWN_VENDOR_MIXED_FILE,
-                getTypicalAddressBook(),
-                NON_DUPLICATE_DETAILS));
-    }
-
-    @Test
-    public void logUnknownVendorIssuesIfDuplicateIdentifier_duplicatePrefix_logsUnknownVendorIssues() {
-        TestableMainApp app = new TestableMainApp();
-
-        assertDoesNotThrow(() -> invokeLogUnknownVendorIssuesIfDuplicateIdentifier(
-                app,
-                UNKNOWN_VENDOR_MIXED_FILE,
-                getTypicalAddressBook(),
-                DUPLICATE_DETAILS));
-    }
-
-    @Test
     public void logIllegalValueIssue_withNewLineInDetails_noException() {
         TestableMainApp app = new TestableMainApp();
 
@@ -416,18 +391,6 @@ public class MainAppTest {
                 inventoryFilePath,
                 exception,
                 initialData);
-    }
-
-    private void invokeLogUnknownVendorIssuesIfDuplicateIdentifier(MainApp app, Path inventoryFilePath,
-                                                                   ReadOnlyAddressBook initialData,
-                                                                   String details) throws Exception {
-        invokePrivateMethod(
-                app,
-                METHOD_LOG_UNKNOWN_VENDOR_ISSUES,
-                new Class<?>[]{Path.class, ReadOnlyAddressBook.class, String.class},
-                inventoryFilePath,
-                initialData,
-                details);
     }
 
     private void invokeLogIllegalValueIssue(MainApp app, Path filePath, String details) throws Exception {

--- a/src/test/java/seedu/address/storage/JsonAddressBookStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonAddressBookStorageTest.java
@@ -3,7 +3,6 @@ package seedu.address.storage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.storage.JsonSerializableAddressBook.MESSAGE_DUPLICATE_PERSON;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.HOON;
@@ -13,7 +12,6 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -26,11 +24,13 @@ public class JsonAddressBookStorageTest {
     private static final Path TEST_DATA_FOLDER = Paths.get("src", "test", "data", "JsonAddressBookStorageTest");
     private static final String MISSING_FILE = "NonExistentFile.json";
     private static final String DUPLICATE_EMAIL_FILE = "duplicateEmailAddressBook.json";
+    private static final String MULTIPLE_DUPLICATE_EMAIL_FILE = "multipleDuplicateEmailAddressBook.json";
     private static final String NOT_JSON_FORMAT_FILE = "notJsonFormatAddressBook.json";
     private static final String INVALID_PERSON_FILE = "invalidPersonAddressBook.json";
     private static final String INVALID_AND_VALID_PERSON_FILE = "invalidAndValidPersonAddressBook.json";
     private static final String SAMPLE_FILE_NAME = "SomeFile.json";
     private static final String DUPLICATE_EMAIL = "alice@example.com";
+    private static final String SECOND_DUPLICATE_EMAIL = "second@example.com";
     private static final String DUPLICATE_CONTACT_EMAIL_PREFIX = "Duplicate contact email '";
     private static final String QUOTE_SUFFIX = "'";
     private static final String DUPLICATE_CONTACT_EMAIL_MESSAGE_SUFFIX = "'.";
@@ -96,24 +96,21 @@ public class JsonAddressBookStorageTest {
         String message = invokeBuildDuplicateEmailErrorMessage(
             storage,
             resolvedMissingFilePath,
-            List.of(DUPLICATE_EMAIL));
+            DUPLICATE_EMAIL);
 
         assertEquals(DUPLICATE_CONTACT_EMAIL_PREFIX + DUPLICATE_EMAIL + DUPLICATE_CONTACT_EMAIL_MESSAGE_SUFFIX,
             message);
     }
 
     @Test
-    public void buildDuplicateEmailErrorMessage_noDuplicateEmails_returnsDefaultDuplicatePersonMessage()
-            throws Exception {
-        Path resolvedDupeEmailFilePath = TEST_DATA_FOLDER.resolve(DUPLICATE_EMAIL_FILE);
-        JsonAddressBookStorage storage = new JsonAddressBookStorage(resolvedDupeEmailFilePath);
+    public void readAddressBook_multipleDuplicateEmailAddressBook_reportsFirstDuplicateOnly() {
+        DataLoadingException exception = org.junit.jupiter.api.Assertions.assertThrows(
+                DataLoadingException.class, () -> readAddressBook(MULTIPLE_DUPLICATE_EMAIL_FILE));
 
-        String message = invokeBuildDuplicateEmailErrorMessage(
-                storage,
-                resolvedDupeEmailFilePath,
-                List.of());
-
-        assertEquals(MESSAGE_DUPLICATE_PERSON, message);
+        String message = exception.getCause().getMessage();
+        assertTrue(message.contains(DUPLICATE_CONTACT_EMAIL_PREFIX + DUPLICATE_EMAIL + QUOTE_SUFFIX));
+        assertFalse(message.contains(SECOND_DUPLICATE_EMAIL));
+        assertFalse(message.contains(";"));
     }
 
     @Test
@@ -166,10 +163,10 @@ public class JsonAddressBookStorageTest {
 
     private String invokeBuildDuplicateEmailErrorMessage(JsonAddressBookStorage storage,
                                                          Path filePath,
-                                                         List<String> duplicateEmails) throws Exception {
+                                                         String duplicateEmail) throws Exception {
         java.lang.reflect.Method method = JsonAddressBookStorage.class
-                .getDeclaredMethod(REFLECTION_BUILD_DUPLICATE_EMAIL_MESSAGE_METHOD, Path.class, List.class);
+                .getDeclaredMethod(REFLECTION_BUILD_DUPLICATE_EMAIL_MESSAGE_METHOD, Path.class, String.class);
         method.setAccessible(true);
-        return (String) method.invoke(storage, filePath, duplicateEmails);
+        return (String) method.invoke(storage, filePath, duplicateEmail);
     }
 }

--- a/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
+++ b/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
@@ -7,6 +7,7 @@ import static seedu.address.testutil.TypicalPersons.ALICE;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
@@ -93,6 +94,40 @@ public class JsonSerializableAddressBookTest {
         JsonSerializableAddressBook data = new JsonSerializableAddressBook(personList);
 
         assertEquals(List.of(), data.findDuplicateEmails());
+    }
+
+    @Test
+    public void findFirstDuplicateEmail_multipleDuplicateEmails_returnsFirstDuplicateEncountered() {
+        List<JsonAdaptedPerson> personList = List.of(
+                new JsonAdaptedPerson(PERSON_ONE_NAME, PERSON_ONE_PHONE,
+                        UNIQUE_EMAIL_IN_UNIQUE_EMAILS_TEST, PERSON_ONE_ADDRESS, List.of()),
+                new JsonAdaptedPerson(PERSON_TWO_NAME, PERSON_TWO_PHONE,
+                        DUPLICATE_EMAIL_IN_NULL_EMAIL_TEST, PERSON_TWO_ADDRESS, List.of()),
+                new JsonAdaptedPerson(PERSON_THREE_NAME, PERSON_THREE_PHONE,
+                        UNIQUE_EMAIL_IN_UNIQUE_EMAILS_TEST, PERSON_THREE_ADDRESS, List.of()),
+                new JsonAdaptedPerson("Four", "91234570", DUPLICATE_EMAIL_IN_NULL_EMAIL_TEST,
+                        "Address Four", List.of())
+        );
+
+        JsonSerializableAddressBook data = new JsonSerializableAddressBook(personList);
+
+        assertEquals(Optional.of(UNIQUE_EMAIL_IN_UNIQUE_EMAILS_TEST), data.findFirstDuplicateEmail());
+    }
+
+    @Test
+    public void findFirstDuplicateEmail_noDuplicateEmails_returnsEmptyOptional() {
+        List<JsonAdaptedPerson> personList = List.of(
+                new JsonAdaptedPerson(PERSON_ONE_NAME, PERSON_ONE_PHONE,
+                        UNIQUE_EMAIL_IN_UNIQUE_EMAILS_TEST, PERSON_ONE_ADDRESS, List.of()),
+                new JsonAdaptedPerson(PERSON_TWO_NAME, PERSON_TWO_PHONE,
+                        DUPLICATE_EMAIL_IN_NULL_EMAIL_TEST, PERSON_TWO_ADDRESS, List.of()),
+                new JsonAdaptedPerson(PERSON_THREE_NAME, PERSON_THREE_PHONE,
+                        null, PERSON_THREE_ADDRESS, List.of())
+        );
+
+        JsonSerializableAddressBook data = new JsonSerializableAddressBook(personList);
+
+        assertEquals(Optional.empty(), data.findFirstDuplicateEmail());
     }
 
 }


### PR DESCRIPTION
Fixes #555

## Changes
1. Inventory path: VV now logs first duplicate id, then fallback warning.
2. AddressBook path: VV now logs first duplicate email, then fallback warning.

## Tests
✅ updated Storage, MainApp tests
✅ smoke