### PR TITLE
Make Jackson errors user-friendly

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -78,6 +78,11 @@ public class MainApp extends Application {
     private static final String MESSAGE_PARSE_FALLBACK = "Malformed JSON.";
     private static final String MESSAGE_CONFIG_FILE_AT = "Config file at ";
     private static final String MESSAGE_PREFERENCE_FILE_AT = "Preference file at ";
+    private static final String MESSAGE_COULD_NOT_BE_LOADED = " could not be loaded.";
+    private static final String MESSAGE_USING_DEFAULT_CONFIG_PROPERTIES = " Using default config properties.";
+    private static final String MESSAGE_USING_DEFAULT_PREFERENCES = " Using default preferences.";
+    private static final String MESSAGE_FAILED_TO_SAVE_CONFIG_FILE = "Failed to save config file : ";
+    private static final String MESSAGE_FAILED_TO_SAVE_PREFERENCE_FILE = "Failed to save preference file : ";
 
     private static final Logger logger = LogsCenter.getLogger(MainApp.class);
 
@@ -338,6 +343,10 @@ public class MainApp extends Application {
         return sourcePrefix + filePath + MESSAGE_LOG_SEPARATOR + flattenForLog(details);
     }
 
+    private String buildNamedCouldNotLoadWarning(String sourcePrefix, Path filePath, String fallbackMessage) {
+        return sourcePrefix + filePath + MESSAGE_COULD_NOT_BE_LOADED + fallbackMessage;
+    }
+
     /**
      * Logs config/prefs load failures.
      */
@@ -383,8 +392,8 @@ public class MainApp extends Application {
             initializedConfig = configOptional.orElse(new Config());
         } catch (DataLoadingException e) {
             logNamedSourceLoadingIssue(MESSAGE_CONFIG_FILE_AT, configFilePathUsed, e);
-            logger.warning(MESSAGE_CONFIG_FILE_AT + configFilePathUsed + " could not be loaded."
-                    + " Using default config properties.");
+            logger.warning(buildNamedCouldNotLoadWarning(MESSAGE_CONFIG_FILE_AT,
+                configFilePathUsed, MESSAGE_USING_DEFAULT_CONFIG_PROPERTIES));
             initializedConfig = new Config();
         }
 
@@ -392,7 +401,7 @@ public class MainApp extends Application {
         try {
             ConfigUtil.saveConfig(initializedConfig, configFilePathUsed);
         } catch (IOException e) {
-            logger.warning("Failed to save config file : " + StringUtil.getDetails(e));
+            logger.warning(MESSAGE_FAILED_TO_SAVE_CONFIG_FILE + StringUtil.getDetails(e));
         }
         return initializedConfig;
     }
@@ -415,8 +424,8 @@ public class MainApp extends Application {
             initializedPrefs = prefsOptional.orElse(new UserPrefs());
         } catch (DataLoadingException e) {
             logNamedSourceLoadingIssue(MESSAGE_PREFERENCE_FILE_AT, prefsFilePath, e);
-            logger.warning(MESSAGE_PREFERENCE_FILE_AT + prefsFilePath + " could not be loaded."
-                    + " Using default preferences.");
+            logger.warning(buildNamedCouldNotLoadWarning(MESSAGE_PREFERENCE_FILE_AT,
+                prefsFilePath, MESSAGE_USING_DEFAULT_PREFERENCES));
             initializedPrefs = new UserPrefs();
         }
 
@@ -424,7 +433,7 @@ public class MainApp extends Application {
         try {
             storage.saveUserPrefs(initializedPrefs);
         } catch (IOException e) {
-            logger.warning("Failed to save config file : " + StringUtil.getDetails(e));
+            logger.warning(MESSAGE_FAILED_TO_SAVE_PREFERENCE_FILE + StringUtil.getDetails(e));
         }
 
         return initializedPrefs;

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -393,7 +393,7 @@ public class MainApp extends Application {
         } catch (DataLoadingException e) {
             logNamedSourceLoadingIssue(MESSAGE_CONFIG_FILE_AT, configFilePathUsed, e);
             logger.warning(buildNamedCouldNotLoadWarning(MESSAGE_CONFIG_FILE_AT,
-                configFilePathUsed, MESSAGE_USING_DEFAULT_CONFIG_PROPERTIES));
+                    configFilePathUsed, MESSAGE_USING_DEFAULT_CONFIG_PROPERTIES));
             initializedConfig = new Config();
         }
 
@@ -425,7 +425,7 @@ public class MainApp extends Application {
         } catch (DataLoadingException e) {
             logNamedSourceLoadingIssue(MESSAGE_PREFERENCE_FILE_AT, prefsFilePath, e);
             logger.warning(buildNamedCouldNotLoadWarning(MESSAGE_PREFERENCE_FILE_AT,
-                prefsFilePath, MESSAGE_USING_DEFAULT_PREFERENCES));
+                    prefsFilePath, MESSAGE_USING_DEFAULT_PREFERENCES));
             initializedPrefs = new UserPrefs();
         }
 

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -4,9 +4,12 @@ import static seedu.address.model.util.VendorVaultConsistencyUtil.validateOrThro
 import static seedu.address.ui.Messages.MESSAGE_COULD_NOT_LOAD_STARTING_EMPTY_ADDRESS_BOOK;
 import static seedu.address.ui.Messages.MESSAGE_COULD_NOT_LOAD_STARTING_EMPTY_ALIAS;
 import static seedu.address.ui.Messages.MESSAGE_COULD_NOT_LOAD_STARTING_EMPTY_INVENTORY;
+import static seedu.address.ui.Messages.MESSAGE_COULD_NOT_READ_DATA_IN;
 import static seedu.address.ui.Messages.MESSAGE_CREATING_NEW_DATA_FILE;
 import static seedu.address.ui.Messages.MESSAGE_DATA_FILE_AT;
 import static seedu.address.ui.Messages.MESSAGE_ILLEGAL_VALUES_FOUND_IN;
+import static seedu.address.ui.Messages.MESSAGE_INVALID_JSON_FORMAT;
+import static seedu.address.ui.Messages.MESSAGE_INVALID_JSON_FORMAT_AT_LINE;
 import static seedu.address.ui.Messages.MESSAGE_LOG_SEPARATOR;
 import static seedu.address.ui.Messages.MESSAGE_POPULATED_EMPTY_ALIAS_FILE;
 import static seedu.address.ui.Messages.MESSAGE_POPULATED_SAMPLE_ADDRESS_BOOK;
@@ -17,6 +20,11 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.core.JsonProcessingException;
 
 import javafx.application.Application;
 import javafx.stage.Stage;
@@ -64,6 +72,12 @@ public class MainApp extends Application {
             "=============================[ Initializing VendorVault ]===========================";
     public static final String LOG_FOOTER =
             "============================ [ Stopping VendorVault ] =============================";
+    private static final Pattern UNRECOGNIZED_TOKEN_PATTERN =
+        Pattern.compile("^Unrecognized token '([^']+)':.*");
+    private static final String MESSAGE_UNRECOGNIZED_TOKEN = "Unrecognized token '";
+    private static final String MESSAGE_PARSE_FALLBACK = "Malformed JSON.";
+    private static final String MESSAGE_CONFIG_FILE_AT = "Config file at ";
+    private static final String MESSAGE_PREFERENCE_FILE_AT = "Preference file at ";
 
     private static final Logger logger = LogsCenter.getLogger(MainApp.class);
 
@@ -122,7 +136,7 @@ public class MainApp extends Application {
 
             return addressBookOptional.orElseGet(SampleDataUtil::getSampleAddressBook);
         } catch (DataLoadingException e) {
-            logLoadingIssue(addressBookFilePath, e);
+            logDataFileLoadingIssue(addressBookFilePath, e);
             logger.warning(buildCouldNotLoadWarning(addressBookFilePath,
                     MESSAGE_COULD_NOT_LOAD_STARTING_EMPTY_ADDRESS_BOOK));
 
@@ -141,13 +155,13 @@ public class MainApp extends Application {
             ReadOnlyInventory initialInventory = inventoryOptional.orElseGet(SampleDataUtil::getSampleInventory);
             return validateInitialInventory(inventoryFilePath, initialData, initialInventory);
         } catch (IllegalValueException e) {
-            logIllegalValueIssue(inventoryFilePath, e.getMessage());
+            logDataValidationIssue(inventoryFilePath, e.getMessage());
             logger.warning(buildCouldNotLoadWarning(inventoryFilePath,
                     MESSAGE_COULD_NOT_LOAD_STARTING_EMPTY_INVENTORY));
 
             return new Inventory();
         } catch (DataLoadingException e) {
-            logInventoryLoadingIssue(inventoryFilePath, e, initialData);
+            logDataFileLoadingIssue(inventoryFilePath, e);
             logger.warning(buildCouldNotLoadWarning(inventoryFilePath,
                     MESSAGE_COULD_NOT_LOAD_STARTING_EMPTY_INVENTORY));
 
@@ -163,16 +177,6 @@ public class MainApp extends Application {
         return initialInventory;
     }
 
-    private void logInventoryLoadingIssue(Path inventoryFilePath, DataLoadingException exception,
-                                          ReadOnlyAddressBook initialData) {
-        Optional<String> illegalValueDetails = logLoadingIssue(inventoryFilePath, exception);
-        if (!illegalValueDetails.isPresent()) {
-            return;
-        }
-
-        String details = illegalValueDetails.get();
-    }
-
     private ReadOnlyAliases loadInitialAliases(Storage storage) {
         Path aliasFilePath = storage.getAliasFilePath();
 
@@ -182,7 +186,7 @@ public class MainApp extends Application {
 
             return aliasesOptional.orElseGet(Aliases::new);
         } catch (DataLoadingException e) {
-            logLoadingIssue(aliasFilePath, e);
+            logDataFileLoadingIssue(aliasFilePath, e);
             logger.warning(buildCouldNotLoadWarning(aliasFilePath,
                     MESSAGE_COULD_NOT_LOAD_STARTING_EMPTY_ALIAS));
 
@@ -200,26 +204,153 @@ public class MainApp extends Application {
         return MESSAGE_DATA_FILE_AT + filePath + fallbackMessage;
     }
 
-    private Optional<String> logLoadingIssue(Path filePath, DataLoadingException exception) {
-        Optional<String> illegalValueDetails = getIllegalValueDetails(exception);
-        illegalValueDetails.ifPresent(details -> logIllegalValueIssue(filePath, details));
-        return illegalValueDetails;
+    /**
+     * Logs the most useful available loading issue detail for data files.
+     *
+     * <p>Preference order:
+     * 1) Illegal value / JSON parse details if available.
+     * 2) Concise root-cause summary otherwise.
+     */
+    private Optional<String> logDataFileLoadingIssue(Path filePath, DataLoadingException exception) {
+        Optional<String> details = extractValidationOrParsingDetails(exception);
+        if (details.isPresent()) {
+            logDataValidationIssue(filePath, details.get());
+            return details;
+        }
+
+        Optional<String> rootCauseSummary = extractRootCauseSummary(exception.getCause());
+        rootCauseSummary.ifPresent(cause -> logDataReadCauseIssue(filePath, cause));
+        return rootCauseSummary;
     }
 
-    private Optional<String> getIllegalValueDetails(DataLoadingException exception) {
+    /**
+     * Extracts detailed startup diagnostics from IllegalValue and JSON processing exceptions.
+     */
+    private Optional<String> extractValidationOrParsingDetails(DataLoadingException exception) {
         Throwable cause = exception.getCause();
+        if (cause instanceof IllegalValueException) {
+            String details = cause.getMessage();
+            if (details == null) {
+                return Optional.empty();
+            }
+            return Optional.of(details);
+        }
 
-        if (!(cause instanceof IllegalValueException)) {
+        return extractJsonParsingDetails(cause);
+    }
+
+    /**
+     * Produces a concise one-line summary for non-JSON root causes.
+     */
+    private Optional<String> extractRootCauseSummary(Throwable cause) {
+        if (cause == null) {
             return Optional.empty();
         }
 
-        String details = cause.getMessage();
-        return details == null ? Optional.empty() : Optional.of(details);
+        Throwable root = cause;
+        while (root.getCause() != null) {
+            root = root.getCause();
+        }
+
+        String className = root.getClass().getSimpleName();
+        String message = root.getMessage();
+        if (message == null || message.trim().isEmpty()) {
+            return Optional.of(className);
+        }
+
+        String firstLine = extractFirstLine(message);
+        return Optional.of(className + MESSAGE_LOG_SEPARATOR + firstLine);
     }
 
-    private void logIllegalValueIssue(Path filePath, String details) {
+    /**
+     * Searches the exception chain for Jackson processing exceptions and formats them for logs.
+     */
+    private Optional<String> extractJsonParsingDetails(Throwable cause) {
+        Throwable current = cause;
+        while (current != null) {
+            if (current instanceof JsonProcessingException) {
+                String details = formatJsonParsingDetails((JsonProcessingException) current);
+                return Optional.of(details);
+            }
+            current = current.getCause();
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Builds a user-facing JSON parse diagnostic with line number when available.
+     */
+    private String formatJsonParsingDetails(JsonProcessingException exception) {
+        String message = normalizeJsonParsingMessage(exception);
+        JsonLocation location = exception.getLocation();
+
+        boolean isValidLocation = (location != null) && (location.getLineNr() > 0);
+        if (isValidLocation) {
+            return MESSAGE_INVALID_JSON_FORMAT_AT_LINE + location.getLineNr() + MESSAGE_LOG_SEPARATOR + message;
+        }
+
+        return MESSAGE_INVALID_JSON_FORMAT + MESSAGE_LOG_SEPARATOR + message;
+    }
+
+    /**
+     * Normalizes Jackson parse messages.
+     */
+    private String normalizeJsonParsingMessage(JsonProcessingException exception) {
+        String originalMessage = exception.getOriginalMessage();
+        String firstLine = extractFirstLine(originalMessage);
+
+        Matcher matcher = UNRECOGNIZED_TOKEN_PATTERN.matcher(firstLine);
+        if (matcher.matches()) {
+            return MESSAGE_UNRECOGNIZED_TOKEN + matcher.group(1) + "'.";
+        }
+
+        if (firstLine.isEmpty()) {
+            return MESSAGE_PARSE_FALLBACK;
+        }
+        return firstLine;
+    }
+
+    /**
+     * Returns the first trimmed line of a possibly multi-line message.
+     */
+    private String extractFirstLine(String message) {
+        if (message == null) {
+            return "";
+        }
+        return message.replace("\r\n", NEWLINE).split(NEWLINE, 2)[0].trim();
+    }
+
+    private String flattenForLog(String details) {
+        return details.replace(NEWLINE, " ");
+    }
+
+    private void logDataValidationIssue(Path filePath, String details) {
         logger.warning(MESSAGE_ILLEGAL_VALUES_FOUND_IN + filePath + MESSAGE_LOG_SEPARATOR
-                + details.replace(NEWLINE, " "));
+                + flattenForLog(details));
+    }
+
+    private void logDataReadCauseIssue(Path filePath, String details) {
+        logger.warning(MESSAGE_COULD_NOT_READ_DATA_IN + filePath + MESSAGE_LOG_SEPARATOR
+                + flattenForLog(details));
+    }
+
+    private String buildNamedLoadingIssueMessage(String sourcePrefix, Path filePath, String details) {
+        return sourcePrefix + filePath + MESSAGE_LOG_SEPARATOR + flattenForLog(details);
+    }
+
+    /**
+     * Logs config/prefs load failures.
+     */
+    private void logNamedSourceLoadingIssue(String sourcePrefix, Path filePath, DataLoadingException exception) {
+        Optional<String> details = extractValidationOrParsingDetails(exception);
+        if (details.isPresent()) {
+            logger.warning(buildNamedLoadingIssueMessage(sourcePrefix, filePath, details.get()));
+            return;
+        }
+
+        extractRootCauseSummary(exception.getCause()).ifPresent(
+                cause -> logger.warning(buildNamedLoadingIssueMessage(sourcePrefix, filePath, cause))
+        );
     }
 
     private void initLogging(Config config) {
@@ -251,7 +382,8 @@ public class MainApp extends Application {
             }
             initializedConfig = configOptional.orElse(new Config());
         } catch (DataLoadingException e) {
-            logger.warning("Config file at " + configFilePathUsed + " could not be loaded."
+            logNamedSourceLoadingIssue(MESSAGE_CONFIG_FILE_AT, configFilePathUsed, e);
+            logger.warning(MESSAGE_CONFIG_FILE_AT + configFilePathUsed + " could not be loaded."
                     + " Using default config properties.");
             initializedConfig = new Config();
         }
@@ -282,7 +414,8 @@ public class MainApp extends Application {
             }
             initializedPrefs = prefsOptional.orElse(new UserPrefs());
         } catch (DataLoadingException e) {
-            logger.warning("Preference file at " + prefsFilePath + " could not be loaded."
+            logNamedSourceLoadingIssue(MESSAGE_PREFERENCE_FILE_AT, prefsFilePath, e);
+            logger.warning(MESSAGE_PREFERENCE_FILE_AT + prefsFilePath + " could not be loaded."
                     + " Using default preferences.");
             initializedPrefs = new UserPrefs();
         }

--- a/src/main/java/seedu/address/commons/util/JsonUtil.java
+++ b/src/main/java/seedu/address/commons/util/JsonUtil.java
@@ -70,7 +70,6 @@ public class JsonUtil {
         try {
             jsonFile = deserializeObjectFromJsonFile(filePath, classOfObjectToDeserialize);
         } catch (IOException e) {
-            logger.warning("Error reading from jsonFile file " + filePath + ": " + e);
             throw new DataLoadingException(e);
         }
 

--- a/src/main/java/seedu/address/ui/Messages.java
+++ b/src/main/java/seedu/address/ui/Messages.java
@@ -5,10 +5,12 @@ package seedu.address.ui;
  */
 public final class Messages {
 
-    public static final String DUPLICATE_IDENTIFIER_PREFIX = "Duplicate product identifier";
     public static final String MESSAGE_DATA_FILE_AT = "Data file at ";
+    public static final String MESSAGE_COULD_NOT_READ_DATA_IN = "Could not read data in ";
     public static final String MESSAGE_CREATING_NEW_DATA_FILE = "Creating a new data file ";
     public static final String MESSAGE_ILLEGAL_VALUES_FOUND_IN = "Illegal value(s) found in ";
+    public static final String MESSAGE_INVALID_JSON_FORMAT = "Invalid JSON format";
+    public static final String MESSAGE_INVALID_JSON_FORMAT_AT_LINE = "Invalid JSON format at line ";
     public static final String MESSAGE_LOG_SEPARATOR = ": ";
     public static final String MESSAGE_COULD_NOT_LOAD_STARTING_EMPTY_ADDRESS_BOOK =
             " could not be loaded. Starting with empty AddressBook.";
@@ -22,7 +24,6 @@ public final class Messages {
             " populated with a sample Inventory.";
     public static final String MESSAGE_POPULATED_EMPTY_ALIAS_FILE =
             " populated with an empty Alias file.";
-    public static final String MESSAGE_UNKNOWN_VENDOR_EMAIL = "Unknown vendor email ";
     public static final String NEWLINE = "\n";
 
     private Messages() {}

--- a/src/test/java/seedu/address/MainAppTest.java
+++ b/src/test/java/seedu/address/MainAppTest.java
@@ -20,6 +20,9 @@ import java.util.logging.Logger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
 import seedu.address.commons.core.Config;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.exceptions.DataLoadingException;
@@ -65,6 +68,9 @@ public class MainAppTest {
     private static final String METHOD_LOAD_INITIAL_ALIASES = "loadInitialAliases";
     private static final String METHOD_EXTRACT_VALIDATION_OR_PARSING_DETAILS =
             "extractValidationOrParsingDetails";
+    private static final String METHOD_FORMAT_JSON_PARSING_DETAILS = "formatJsonParsingDetails";
+    private static final String METHOD_NORMALIZE_JSON_PARSING_MESSAGE = "normalizeJsonParsingMessage";
+    private static final String METHOD_EXTRACT_FIRST_LINE = "extractFirstLine";
     private static final String METHOD_INIT_MODEL_MANAGER = "initModelManager";
     private static final String METHOD_LOG_DATA_VALIDATION_ISSUE = "logDataValidationIssue";
     private static final String METHOD_INIT_LOGGING = "initLogging";
@@ -74,6 +80,9 @@ public class MainAppTest {
     private static final String INVALID_JSON_GENERIC_PREFIX = "Invalid JSON format";
     private static final String INVALID_JSON_TOKEN_DETAILS = "Unrecognized token 'hello'.";
     private static final String INVALID_JSON_LINE_PREFIX = "Invalid JSON format at line 1: ";
+    private static final String JSON_PARSE_FALLBACK_MESSAGE = "Malformed JSON.";
+    private static final String GENERIC_JSON_PARSE_MESSAGE = "Unexpected close marker";
+    private static final JsonLocation UNKNOWN_LOCATION = new JsonLocation("source", -1L, -1L, 0, 1);
     private static final String CONFIG_FILE_PREFIX = "Config file at ";
     private static final String PREFS_FILE_PREFIX = "Preference file at ";
     private static final String READ_DATA_PREFIX = "Could not read data in ";
@@ -385,6 +394,35 @@ public class MainAppTest {
     }
 
     @Test
+    public void formatJsonParsingDetails_locationLineNotPositive_returnsGenericFormatMessage() throws Exception {
+        TestableMainApp app = new TestableMainApp();
+        JsonProcessingException exception = createJsonProcessingException(GENERIC_JSON_PARSE_MESSAGE, UNKNOWN_LOCATION);
+
+        String details = invokeFormatJsonParsingDetails(app, exception);
+
+        assertEquals(INVALID_JSON_GENERIC_PREFIX + ": " + GENERIC_JSON_PARSE_MESSAGE, details);
+    }
+
+    @Test
+    public void normalizeJsonParsingMessage_emptyOriginalMessage_returnsFallback() throws Exception {
+        TestableMainApp app = new TestableMainApp();
+        JsonProcessingException exception = createJsonProcessingException("", null);
+
+        String message = invokeNormalizeJsonParsingMessage(app, exception);
+
+        assertEquals(JSON_PARSE_FALLBACK_MESSAGE, message);
+    }
+
+    @Test
+    public void extractFirstLine_nullMessage_returnsEmptyString() throws Exception {
+        TestableMainApp app = new TestableMainApp();
+
+        String firstLine = invokeExtractFirstLine(app, null);
+
+        assertEquals("", firstLine);
+    }
+
+    @Test
     public void initModelManager_emptyStorageData_returnsModelWithSampleData() throws Exception {
         TestableMainApp app = new TestableMainApp();
         ReadableStorageStub storageStub = new ReadableStorageStub();
@@ -476,6 +514,30 @@ public class MainAppTest {
                 exception);
     }
 
+    private String invokeFormatJsonParsingDetails(MainApp app, JsonProcessingException exception) throws Exception {
+        return (String) invokePrivateMethod(
+                app,
+                METHOD_FORMAT_JSON_PARSING_DETAILS,
+                new Class<?>[]{JsonProcessingException.class},
+                exception);
+    }
+
+    private String invokeNormalizeJsonParsingMessage(MainApp app, JsonProcessingException exception) throws Exception {
+        return (String) invokePrivateMethod(
+                app,
+                METHOD_NORMALIZE_JSON_PARSING_MESSAGE,
+                new Class<?>[]{JsonProcessingException.class},
+                exception);
+    }
+
+    private String invokeExtractFirstLine(MainApp app, String message) throws Exception {
+        return (String) invokePrivateMethod(
+                app,
+                METHOD_EXTRACT_FIRST_LINE,
+                new Class<?>[]{String.class},
+                message);
+    }
+
     private Object invokePrivateMethod(MainApp app, String methodName, Class<?>[] parameterTypes, Object... args)
             throws Exception {
         Method method = MainApp.class.getDeclaredMethod(methodName, parameterTypes);
@@ -490,6 +552,12 @@ public class MainAppTest {
         } catch (IOException ioe) {
             return ioe;
         }
+    }
+
+    private JsonProcessingException createJsonProcessingException(String message, JsonLocation location) {
+        return new JsonProcessingException(message, location) {
+            private static final long serialVersionUID = 1L;
+        };
     }
 
     private void withMainAppLogger(ThrowingConsumer<CapturingLogHandler> assertion) {

--- a/src/test/java/seedu/address/MainAppTest.java
+++ b/src/test/java/seedu/address/MainAppTest.java
@@ -3,7 +3,6 @@ package seedu.address;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalProducts.RICE;
 
 import java.io.IOException;
@@ -26,6 +25,7 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.exceptions.DataLoadingException;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.ConfigUtil;
+import seedu.address.commons.util.JsonUtil;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Aliases;
 import seedu.address.model.Inventory;
@@ -63,14 +63,21 @@ public class MainAppTest {
     private static final String METHOD_LOAD_INITIAL_ADDRESS_BOOK = "loadInitialAddressBook";
     private static final String METHOD_LOAD_INITIAL_INVENTORY = "loadInitialInventory";
     private static final String METHOD_LOAD_INITIAL_ALIASES = "loadInitialAliases";
-    private static final String METHOD_GET_ILLEGAL_VALUE_DETAILS = "getIllegalValueDetails";
+    private static final String METHOD_EXTRACT_VALIDATION_OR_PARSING_DETAILS =
+            "extractValidationOrParsingDetails";
     private static final String METHOD_INIT_MODEL_MANAGER = "initModelManager";
-    private static final String METHOD_LOG_INVENTORY_LOADING_ISSUE = "logInventoryLoadingIssue";
-    private static final String METHOD_LOG_ILLEGAL_VALUE_ISSUE = "logIllegalValueIssue";
+    private static final String METHOD_LOG_DATA_VALIDATION_ISSUE = "logDataValidationIssue";
     private static final String METHOD_INIT_LOGGING = "initLogging";
-    private static final String NON_DUPLICATE_DETAILS = "Some non-duplicate error";
+    private static final String IO_EXCEPTION_DETAILS = "IOException: " + READ_FAILURE_MESSAGE;
     private static final String DETAILS_WITH_NEWLINE = "line one\nline two";
-    private static final Path UNKNOWN_VENDOR_MIXED_FILE = Path.of("src", "test", "data",
+    private static final String INVALID_JSON_WITH_UNQUOTED_TOKEN = "{\"vendorEmail\": hello@synapse.sg}";
+    private static final String INVALID_JSON_GENERIC_PREFIX = "Invalid JSON format";
+    private static final String INVALID_JSON_TOKEN_DETAILS = "Unrecognized token 'hello'.";
+    private static final String INVALID_JSON_LINE_PREFIX = "Invalid JSON format at line 1: ";
+    private static final String CONFIG_FILE_PREFIX = "Config file at ";
+    private static final String PREFS_FILE_PREFIX = "Preference file at ";
+    private static final String READ_DATA_PREFIX = "Could not read data in ";
+    private static final Path LOG_TEST_FILE = Path.of("src", "test", "data",
             "VendorVaultConsistencyUtilTest", "unknownVendorMixedInventory.json");
 
     @TempDir
@@ -115,6 +122,18 @@ public class MainAppTest {
     }
 
     @Test
+    public void initConfig_invalidCustomFile_logsFriendlyJsonParseDetails() throws Exception {
+        TestableMainApp app = new TestableMainApp();
+        Path configPath = testFolder.resolve(CONFIG_FILE);
+        Files.writeString(configPath, INVALID_CONFIG_CONTENT);
+
+        withMainAppLogger(handler -> {
+            app.callInitConfig(configPath);
+            assertTrue(handler.contains(CONFIG_FILE_PREFIX + configPath + ": " + INVALID_JSON_GENERIC_PREFIX));
+        });
+    }
+
+    @Test
     public void initPrefs_readReturnsEmpty_returnsDefaultAndSaves() {
         TestableMainApp app = new TestableMainApp();
         UserPrefsStorageStub storageStub = new UserPrefsStorageStub(testFolder.resolve(PREFS_FILE));
@@ -136,6 +155,23 @@ public class MainAppTest {
 
         assertEquals(new UserPrefs(), prefs);
         assertEquals(expectedCallCount, storageStub.saveUserPrefsCallCount);
+    }
+
+    @Test
+    public void initPrefs_jsonParseFailure_logsFriendlyJsonParseDetailsAndReturnsDefault() {
+        TestableMainApp app = new TestableMainApp();
+        UserPrefsStorageStub storageStub = new UserPrefsStorageStub(testFolder.resolve(PREFS_FILE));
+        storageStub.readException = new DataLoadingException(createMalformedJsonIoException());
+
+        withMainAppLogger(handler -> {
+            UserPrefs prefs = app.callInitPrefs(storageStub);
+
+            assertEquals(new UserPrefs(), prefs);
+            assertEquals(expectedCallCount, storageStub.saveUserPrefsCallCount);
+            assertTrue(handler.contains(PREFS_FILE_PREFIX + storageStub.getUserPrefsFilePath() + ": "
+                    + INVALID_JSON_LINE_PREFIX));
+            assertTrue(handler.contains(INVALID_JSON_TOKEN_DETAILS));
+        });
     }
 
     @Test
@@ -203,24 +239,31 @@ public class MainAppTest {
     }
 
     @Test
+    public void loadInitialAddressBook_dataLoadingException_logsConciseCause() throws Exception {
+        TestableMainApp app = new TestableMainApp();
+        ReadableStorageStub storageStub = new ReadableStorageStub();
+        storageStub.addressBookReadException = new DataLoadingException(new IOException(READ_FAILURE_MESSAGE));
+
+        withMainAppLogger(handler -> {
+            invokeLoadInitialAddressBook(app, storageStub);
+            assertTrue(handler.contains(READ_DATA_PREFIX + storageStub.getAddressBookFilePath()
+                    + ": " + IO_EXCEPTION_DETAILS));
+        });
+    }
+
+    @Test
     public void loadInitialAddressBook_duplicateEmailDetails_logsAndReturnsEmptyAddressBook() throws Exception {
         TestableMainApp app = new TestableMainApp();
         ReadableStorageStub storageStub = new ReadableStorageStub();
         storageStub.addressBookReadException = new DataLoadingException(new IllegalValueException(
                 DUPLICATE_EMAIL_DETAILS));
 
-        Logger mainAppLogger = LogsCenter.getLogger(MainApp.class);
-        CapturingLogHandler handler = new CapturingLogHandler();
-        mainAppLogger.addHandler(handler);
-
-        try {
+        withMainAppLogger(handler -> {
             ReadOnlyAddressBook initialData = invokeLoadInitialAddressBook(app, storageStub);
 
             assertEquals(new AddressBook(), new AddressBook(initialData));
             assertTrue(handler.contains(DUPLICATE_EMAIL_DETAILS));
-        } finally {
-            mainAppLogger.removeHandler(handler);
-        }
+        });
     }
 
     @Test
@@ -287,33 +330,58 @@ public class MainAppTest {
     }
 
     @Test
-    public void getIllegalValueDetails_illegalValueCause_returnsDetails() throws Exception {
+    public void extractValidationOrParsingDetails_illegalValueCause_returnsDetails() throws Exception {
         TestableMainApp app = new TestableMainApp();
         DataLoadingException exception = new DataLoadingException(new IllegalValueException(ILLEGAL_VALUE_MESSAGE));
 
-        Optional<String> details = invokeGetIllegalValueDetails(app, exception);
+        Optional<String> details = invokeExtractValidationOrParsingDetails(app, exception);
 
         assertEquals(Optional.of(ILLEGAL_VALUE_MESSAGE), details);
     }
 
     @Test
-    public void getIllegalValueDetails_nonIllegalCause_returnsEmpty() throws Exception {
+    public void extractValidationOrParsingDetails_nonIllegalCause_returnsEmpty() throws Exception {
         TestableMainApp app = new TestableMainApp();
         DataLoadingException exception = new DataLoadingException(new IOException(READ_FAILURE_MESSAGE));
 
-        Optional<String> details = invokeGetIllegalValueDetails(app, exception);
+        Optional<String> details = invokeExtractValidationOrParsingDetails(app, exception);
 
         assertEquals(Optional.empty(), details);
     }
 
     @Test
-    public void getIllegalValueDetails_illegalValueCauseWithNullMessage_returnsEmpty() throws Exception {
+    public void extractValidationOrParsingDetails_illegalValueCauseWithNullMessage_returnsEmpty() throws Exception {
         TestableMainApp app = new TestableMainApp();
         DataLoadingException exception = new DataLoadingException(new IllegalValueException((String) null));
 
-        Optional<String> details = invokeGetIllegalValueDetails(app, exception);
+        Optional<String> details = invokeExtractValidationOrParsingDetails(app, exception);
 
         assertEquals(Optional.empty(), details);
+    }
+
+    @Test
+    public void extractValidationOrParsingDetails_jsonParseCause_returnsFriendlyLineMessage() throws Exception {
+        TestableMainApp app = new TestableMainApp();
+        DataLoadingException exception = new DataLoadingException(createMalformedJsonIoException());
+
+        Optional<String> details = invokeExtractValidationOrParsingDetails(app, exception);
+
+        assertTrue(details.isPresent());
+        assertTrue(details.get().startsWith(INVALID_JSON_LINE_PREFIX));
+        assertTrue(details.get().contains(INVALID_JSON_TOKEN_DETAILS));
+    }
+
+    @Test
+    public void extractValidationOrParsingDetails_nestedJsonParseCause_returnsFriendlyLineMessage() throws Exception {
+        TestableMainApp app = new TestableMainApp();
+        DataLoadingException exception = new DataLoadingException(
+                new IOException(READ_FAILURE_MESSAGE, createMalformedJsonIoException()));
+
+        Optional<String> details = invokeExtractValidationOrParsingDetails(app, exception);
+
+        assertTrue(details.isPresent());
+        assertTrue(details.get().startsWith(INVALID_JSON_LINE_PREFIX));
+        assertTrue(details.get().contains(INVALID_JSON_TOKEN_DETAILS));
     }
 
     @Test
@@ -337,32 +405,10 @@ public class MainAppTest {
     }
 
     @Test
-    public void logInventoryLoadingIssue_nonIllegalCause_returnsEarly() {
+    public void logDataValidationIssue_withNewLineInDetails_noException() {
         TestableMainApp app = new TestableMainApp();
 
-        assertDoesNotThrow(() -> invokeLogInventoryLoadingIssue(
-                app,
-                UNKNOWN_VENDOR_MIXED_FILE,
-                new DataLoadingException(new IOException(READ_FAILURE_MESSAGE)),
-                getTypicalAddressBook()));
-    }
-
-    @Test
-    public void logInventoryLoadingIssue_illegalValueCause_logsIllegalValueIssuePath() {
-        TestableMainApp app = new TestableMainApp();
-
-        assertDoesNotThrow(() -> invokeLogInventoryLoadingIssue(
-                app,
-                UNKNOWN_VENDOR_MIXED_FILE,
-                new DataLoadingException(new IllegalValueException(NON_DUPLICATE_DETAILS)),
-                getTypicalAddressBook()));
-    }
-
-    @Test
-    public void logIllegalValueIssue_withNewLineInDetails_noException() {
-        TestableMainApp app = new TestableMainApp();
-
-        assertDoesNotThrow(() -> invokeLogIllegalValueIssue(app, UNKNOWN_VENDOR_MIXED_FILE, DETAILS_WITH_NEWLINE));
+        assertDoesNotThrow(() -> invokeLogDataValidationIssue(app, LOG_TEST_FILE, DETAILS_WITH_NEWLINE));
     }
 
     @Test
@@ -382,21 +428,10 @@ public class MainAppTest {
                 userPrefs);
     }
 
-    private void invokeLogInventoryLoadingIssue(MainApp app, Path inventoryFilePath, DataLoadingException exception,
-                                                ReadOnlyAddressBook initialData) throws Exception {
+    private void invokeLogDataValidationIssue(MainApp app, Path filePath, String details) throws Exception {
         invokePrivateMethod(
                 app,
-                METHOD_LOG_INVENTORY_LOADING_ISSUE,
-                new Class<?>[]{Path.class, DataLoadingException.class, ReadOnlyAddressBook.class},
-                inventoryFilePath,
-                exception,
-                initialData);
-    }
-
-    private void invokeLogIllegalValueIssue(MainApp app, Path filePath, String details) throws Exception {
-        invokePrivateMethod(
-                app,
-                METHOD_LOG_ILLEGAL_VALUE_ISSUE,
+                METHOD_LOG_DATA_VALIDATION_ISSUE,
                 new Class<?>[]{Path.class, String.class},
                 filePath,
                 details);
@@ -432,11 +467,11 @@ public class MainAppTest {
     }
 
     @SuppressWarnings("unchecked")
-    private Optional<String> invokeGetIllegalValueDetails(MainApp app, DataLoadingException exception)
+    private Optional<String> invokeExtractValidationOrParsingDetails(MainApp app, DataLoadingException exception)
             throws Exception {
         return (Optional<String>) invokePrivateMethod(
                 app,
-                METHOD_GET_ILLEGAL_VALUE_DETAILS,
+                METHOD_EXTRACT_VALIDATION_OR_PARSING_DETAILS,
                 new Class<?>[]{DataLoadingException.class},
                 exception);
     }
@@ -446,6 +481,34 @@ public class MainAppTest {
         Method method = MainApp.class.getDeclaredMethod(methodName, parameterTypes);
         method.setAccessible(true);
         return method.invoke(app, args);
+    }
+
+    private IOException createMalformedJsonIoException() {
+        try {
+            JsonUtil.fromJsonString(INVALID_JSON_WITH_UNQUOTED_TOKEN, Object.class);
+            throw new AssertionError("Expected malformed JSON to throw IOException");
+        } catch (IOException ioe) {
+            return ioe;
+        }
+    }
+
+    private void withMainAppLogger(ThrowingConsumer<CapturingLogHandler> assertion) {
+        Logger mainAppLogger = LogsCenter.getLogger(MainApp.class);
+        CapturingLogHandler handler = new CapturingLogHandler();
+        mainAppLogger.addHandler(handler);
+
+        try {
+            assertion.accept(handler);
+        } catch (Exception e) {
+            throw new AssertionError("Unexpected exception during log assertion", e);
+        } finally {
+            mainAppLogger.removeHandler(handler);
+        }
+    }
+
+    @FunctionalInterface
+    private interface ThrowingConsumer<T> {
+        void accept(T value) throws Exception;
     }
 
     private static class TestableMainApp extends MainApp {

--- a/src/test/java/seedu/address/MainAppTest.java
+++ b/src/test/java/seedu/address/MainAppTest.java
@@ -89,6 +89,7 @@ public class MainAppTest {
     private static final String CONFIG_FILE_PREFIX = "Config file at ";
     private static final String PREFS_FILE_PREFIX = "Preference file at ";
     private static final String READ_DATA_PREFIX = "Could not read data in ";
+    private static final String FAILED_SAVE_CONFIG_PREFIX = "Failed to save config file :";
     private static final Path LOG_TEST_FILE = Path.of("src", "test", "data",
             "VendorVaultConsistencyUtilTest", "unknownVendorMixedInventory.json");
 
@@ -142,6 +143,19 @@ public class MainAppTest {
         withMainAppLogger(handler -> {
             app.callInitConfig(configPath);
             assertTrue(handler.contains(CONFIG_FILE_PREFIX + configPath + ": " + INVALID_JSON_GENERIC_PREFIX));
+        });
+    }
+
+    @Test
+    public void initConfig_saveConfigThrowsIoException_logsWarningAndReturnsConfig() throws Exception {
+        TestableMainApp app = new TestableMainApp();
+        Path directoryPath = Files.createDirectories(testFolder.resolve("config-directory"));
+
+        withMainAppLogger(handler -> {
+            Config config = app.callInitConfig(directoryPath);
+
+            assertEquals(new Config(), config);
+            assertTrue(handler.contains(FAILED_SAVE_CONFIG_PREFIX));
         });
     }
 

--- a/src/test/java/seedu/address/MainAppTest.java
+++ b/src/test/java/seedu/address/MainAppTest.java
@@ -68,6 +68,7 @@ public class MainAppTest {
     private static final String METHOD_LOAD_INITIAL_ALIASES = "loadInitialAliases";
     private static final String METHOD_EXTRACT_VALIDATION_OR_PARSING_DETAILS =
             "extractValidationOrParsingDetails";
+    private static final String METHOD_EXTRACT_ROOT_CAUSE_SUMMARY = "extractRootCauseSummary";
     private static final String METHOD_FORMAT_JSON_PARSING_DETAILS = "formatJsonParsingDetails";
     private static final String METHOD_NORMALIZE_JSON_PARSING_MESSAGE = "normalizeJsonParsingMessage";
     private static final String METHOD_EXTRACT_FIRST_LINE = "extractFirstLine";
@@ -82,6 +83,8 @@ public class MainAppTest {
     private static final String INVALID_JSON_LINE_PREFIX = "Invalid JSON format at line 1: ";
     private static final String JSON_PARSE_FALLBACK_MESSAGE = "Malformed JSON.";
     private static final String GENERIC_JSON_PARSE_MESSAGE = "Unexpected close marker";
+    private static final String INVALID_JSON_GENERIC_DETAILS =
+            INVALID_JSON_GENERIC_PREFIX + ": " + GENERIC_JSON_PARSE_MESSAGE;
     private static final JsonLocation UNKNOWN_LOCATION = new JsonLocation("source", -1L, -1L, 0, 1);
     private static final String CONFIG_FILE_PREFIX = "Config file at ";
     private static final String PREFS_FILE_PREFIX = "Preference file at ";
@@ -394,13 +397,64 @@ public class MainAppTest {
     }
 
     @Test
+    public void extractRootCauseSummary_nullCause_returnsEmpty() throws Exception {
+        TestableMainApp app = new TestableMainApp();
+
+        Optional<String> details = invokeExtractRootCauseSummary(app, null);
+
+        assertEquals(Optional.empty(), details);
+    }
+
+    @Test
+    public void extractRootCauseSummary_nestedCauseWithNullMessage_returnsRootClassName() throws Exception {
+        TestableMainApp app = new TestableMainApp();
+        Throwable root = new IllegalArgumentException((String) null);
+        Throwable mid = new RuntimeException("mid", root);
+        Throwable top = new IOException("top", mid);
+
+        Optional<String> details = invokeExtractRootCauseSummary(app, top);
+
+        assertEquals(Optional.of("IllegalArgumentException"), details);
+    }
+
+    @Test
+    public void extractRootCauseSummary_blankRootMessage_returnsRootClassName() throws Exception {
+        TestableMainApp app = new TestableMainApp();
+
+        Optional<String> details = invokeExtractRootCauseSummary(app, new IllegalStateException("   "));
+
+        assertEquals(Optional.of("IllegalStateException"), details);
+    }
+
+    @Test
+    public void extractRootCauseSummary_nestedCauseWithMultilineMessage_returnsClassAndFirstLine() throws Exception {
+        TestableMainApp app = new TestableMainApp();
+        Throwable root = new IOException("root message\nextra details");
+        Throwable top = new RuntimeException("wrapper", root);
+
+        Optional<String> details = invokeExtractRootCauseSummary(app, top);
+
+        assertEquals(Optional.of("IOException: root message"), details);
+    }
+
+    @Test
+    public void formatJsonParsingDetails_nullLocation_returnsGenericFormatMessage() throws Exception {
+        TestableMainApp app = new TestableMainApp();
+        JsonProcessingException exception = createJsonProcessingException(GENERIC_JSON_PARSE_MESSAGE, null);
+
+        String details = invokeFormatJsonParsingDetails(app, exception);
+
+        assertEquals(INVALID_JSON_GENERIC_DETAILS, details);
+    }
+
+    @Test
     public void formatJsonParsingDetails_locationLineNotPositive_returnsGenericFormatMessage() throws Exception {
         TestableMainApp app = new TestableMainApp();
         JsonProcessingException exception = createJsonProcessingException(GENERIC_JSON_PARSE_MESSAGE, UNKNOWN_LOCATION);
 
         String details = invokeFormatJsonParsingDetails(app, exception);
 
-        assertEquals(INVALID_JSON_GENERIC_PREFIX + ": " + GENERIC_JSON_PARSE_MESSAGE, details);
+        assertEquals(INVALID_JSON_GENERIC_DETAILS, details);
     }
 
     @Test
@@ -512,6 +566,15 @@ public class MainAppTest {
                 METHOD_EXTRACT_VALIDATION_OR_PARSING_DETAILS,
                 new Class<?>[]{DataLoadingException.class},
                 exception);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Optional<String> invokeExtractRootCauseSummary(MainApp app, Throwable cause) throws Exception {
+        return (Optional<String>) invokePrivateMethod(
+                app,
+                METHOD_EXTRACT_ROOT_CAUSE_SUMMARY,
+                new Class<?>[]{Throwable.class},
+                cause);
     }
 
     private String invokeFormatJsonParsingDetails(MainApp app, JsonProcessingException exception) throws Exception {
@@ -631,9 +694,15 @@ public class MainAppTest {
     }
 
     private static class StorageStub implements Storage {
+        private static final String METHOD_SHOULD_NOT_BE_CALLED_MESSAGE = "This method should not be called.";
+
         private int saveUserPrefsCallCount;
         private ReadOnlyUserPrefs savedUserPrefs;
         private IOException saveException;
+
+        private AssertionError methodShouldNotBeCalledError() {
+            return new AssertionError(METHOD_SHOULD_NOT_BE_CALLED_MESSAGE);
+        }
 
         @Override
         public void saveUserPrefs(ReadOnlyUserPrefs userPrefs) throws IOException {
@@ -646,87 +715,87 @@ public class MainAppTest {
 
         @Override
         public Optional<UserPrefs> readUserPrefs() throws DataLoadingException {
-            throw new AssertionError("This method should not be called.");
+            throw methodShouldNotBeCalledError();
         }
 
         @Override
         public Path getUserPrefsFilePath() {
-            throw new AssertionError("This method should not be called.");
+            throw methodShouldNotBeCalledError();
         }
 
         @Override
         public Path getAddressBookFilePath() {
-            throw new AssertionError("This method should not be called.");
+            throw methodShouldNotBeCalledError();
         }
 
         @Override
         public Optional<ReadOnlyAddressBook> readAddressBook() throws DataLoadingException {
-            throw new AssertionError("This method should not be called.");
+            throw methodShouldNotBeCalledError();
         }
 
         @Override
         public Optional<ReadOnlyAddressBook> readAddressBook(Path filePath) throws DataLoadingException {
-            throw new AssertionError("This method should not be called.");
+            throw methodShouldNotBeCalledError();
         }
 
         @Override
         public void saveAddressBook(ReadOnlyAddressBook addressBook) {
-            throw new AssertionError("This method should not be called.");
+            throw methodShouldNotBeCalledError();
         }
 
         @Override
         public void saveAddressBook(ReadOnlyAddressBook addressBook, Path filePath) {
-            throw new AssertionError("This method should not be called.");
+            throw methodShouldNotBeCalledError();
         }
 
         @Override
         public Path getInventoryFilePath() {
-            throw new AssertionError("This method should not be called.");
+            throw methodShouldNotBeCalledError();
         }
 
         @Override
         public Optional<ReadOnlyInventory> readInventory() throws DataLoadingException {
-            throw new AssertionError("This method should not be called.");
+            throw methodShouldNotBeCalledError();
         }
 
         @Override
         public Optional<ReadOnlyInventory> readInventory(Path filePath) throws DataLoadingException {
-            throw new AssertionError("This method should not be called.");
+            throw methodShouldNotBeCalledError();
         }
 
         @Override
         public void saveInventory(ReadOnlyInventory inventory) {
-            throw new AssertionError("This method should not be called.");
+            throw methodShouldNotBeCalledError();
         }
 
         @Override
         public void saveInventory(ReadOnlyInventory inventory, Path filePath) {
-            throw new AssertionError("This method should not be called.");
+            throw methodShouldNotBeCalledError();
         }
 
         @Override
         public Path getAliasFilePath() {
-            throw new AssertionError("This method should not be called.");
+            throw methodShouldNotBeCalledError();
         }
 
         @Override
         public Optional<ReadOnlyAliases> readAliases() throws DataLoadingException {
-            throw new AssertionError("This method should not be called.");
+            throw methodShouldNotBeCalledError();
         }
 
         @Override
         public Optional<ReadOnlyAliases> readAliases(Path filePath) throws DataLoadingException {
-            throw new AssertionError("This method should not be called.");
+            throw methodShouldNotBeCalledError();
         }
 
         @Override
         public void saveAliases(ReadOnlyAliases aliases) {
-            throw new AssertionError("This method should not be called.");
+            throw methodShouldNotBeCalledError();
         }
 
         @Override
         public void saveAliases(ReadOnlyAliases aliases, Path filePath) {
-            throw new AssertionError("This method should not be called.");
+            throw methodShouldNotBeCalledError();
         }
     }
 


### PR DESCRIPTION
### Summary
- log Jackson errors as user-friendly messages
- make config/prefs logs consistent with data logs
- clean up code and tests

fixes #554 